### PR TITLE
Files and changes for publishing

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people
+who contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual
+language or imagery, derogatory comments or personal attacks, trolling, public
+or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct. Project maintainers who do not follow the
+Code of Conduct may be removed from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by opening an issue or contacting one or more of the project
+maintainers.
+
+This Code of Conduct is adapted from the [Contributor
+Covenant](http://contributor-covenant.org), version 1.0.0, available at
+[http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Sealink Travel Group Limited
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# docker-eb-deploy
+
+docker-eb-deploy is a gem for facilitating Elastic Beanstalk deployment of
+Docker images built automatically by Docker Hub or another third party service.
+
+Currently it allows you to create a release and trigger the build automation in
+Docker Hub.
+
+## Installation
+
+For multiple application usage, install the gem directly (in the global gem
+space if you're using rbenv or rvm):
+
+```shell
+gem install docker-eb-deploy
+```
+
+## Usage
+
+Execute `docker-release` in your project directory
+that contains the Dockerrun.aws.json file.
+
+## Development
+
+Bundler is recommended for managing the development dependencies.
+
+Rspec tests are located in the `spec` directory.
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/sealink/docker-deploy. This project is intended to be a safe,
+welcoming space for collaboration, and contributors are expected to adhere to
+the [Contributor Covenant](contributor-covenant.org) code of conduct.
+
+## License
+
+The gem is available as open source under the terms of the [MIT
+License](http://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ that contains the Dockerrun.aws.json file.
 
 Bundler is recommended for managing the development dependencies.
 
-Rspec tests are located in the `spec` directory.
+Rspec tests are located in the `spec` directory.  Just run `rspec` in the root
+directory of the project to run all the bundled specs.
 
 ## Contributing
 

--- a/docker-eb-deploy.gemspec
+++ b/docker-eb-deploy.gemspec
@@ -5,14 +5,14 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'docker/deploy/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'docker-deploy'
+  spec.name          = 'docker-eb-deploy'
   spec.version       = Docker::Deploy::VERSION
   spec.authors       = [ 'Alvin Yim' ]
   spec.email         = [ 'alvin.yim@sealink.com.au' ]
 
   spec.summary       = 'Tag the Git repo for Docker Hub to build the image'
-  spec.description   = 'Tag the Git repo for Docker Hub to build the image'
-  spec.homepage      = 'https://github.com/sealink/docker-deploy'
+  spec.description   = 'Tag the Git repo for Docker Hub to build the image for Elastic Beanstalk'
+  spec.homepage      = 'https://github.com/sealink/docker-eb-deploy'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match %r{^(test|spec|features)/} }
@@ -22,4 +22,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = [ 'lib' ]
 
   spec.add_dependency 'deploy_aws', '~> 0.1.0'
+
+  spec.add_development_dependency 'rspec', '~> 3.4.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+end


### PR DESCRIPTION
# Why?

The name of the project has been changed in this PR.  There is a gem called `docker-deploy` in rubygems.org already.  😿

The other files in this PR are for preparing the project for publication.

There is another PR following this one.  This PR helps to reduce the size of the next one so that it will be more focused to the actual functionality rather than the boilerplate content in this PR. 
